### PR TITLE
Fixed PanelScheduleView Name Update

### DIFF
--- a/CMW_Electrical/CMW_Electrical_Ribbon.cs
+++ b/CMW_Electrical/CMW_Electrical_Ribbon.cs
@@ -140,7 +140,7 @@ namespace CMW_Electrical
                 "Panel Name" + System.Environment.NewLine + " Updater ",
                 thisAssemblyPath, "EquipNameUpdate.EquipInfoUpdate");
 
-            PushButton equipUpdateBtn = devicePanel.AddItem(equipUpdateData) as PushButton;
+            PushButton equipUpdateBtn = equipPanel.AddItem(equipUpdateData) as PushButton;
             //equipUpdateBtn ToolTip Information
             equipUpdateBtn.ToolTip = "Update ALL Electrical Equipment Name Information";
             equipUpdateBtn.LongDescription = "";


### PR DESCRIPTION
Resolved issue where associated PanelScheduleViews were not being updated. Simplified the EquipCircuits2020 function to have a more simplified approach and consistent utilization in the main code.
![image](https://user-images.githubusercontent.com/119504422/221602890-1513b0d8-f83c-43fb-a760-be07a2d968a2.png)
![image](https://user-images.githubusercontent.com/119504422/221602969-ca63b95b-38b0-4782-a756-fb164488f116.png)
